### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - name: Run actionlint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,11 @@ jobs:
           - '4.0'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.307.0
+        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1.307.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
## Summary

Pin every third-party `uses:` reference in `.github/workflows/*.yml` to a commit SHA, with the original tag preserved as a trailing comment.

This is the standard mitigation against tag mutability — a tag like `@v3` can be force-moved to point at a different commit (intentionally or via repo compromise), and any workflow consuming that tag would silently execute the new code. Pinning to a SHA removes that surface; Dependabot still tracks the tag comment to file version-bump PRs.

This is the first of a series of `zizmor` findings to address; SHA pinning resolves the `unpinned-uses` audit.

## Test plan

- [x] `actionlint` passes
- [ ] CI still runs to completion on this PR