### PR TITLE
ci: declare top-level permissions in workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Declare an explicit top-level `permissions:` block on both workflows so the workflow's default `GITHUB_TOKEN` is restricted to read-only access to repository contents.

This addresses the `excessive-permissions` finding from `zizmor`. Without an explicit declaration, GitHub falls back to the repository default token permissions, which can be much broader than what the workflow uses.

- `main.yml` — runs tests via `bundle exec rake`; `contents: read` is enough.
- `actionlint.yml` — runs the linter on checked-out source; `contents: read` is enough.

References:
- https://docs.zizmor.sh/audits/#excessive-permissions
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

## Test plan

- [x] Run the affected workflows on this PR and confirm they still pass.