### PR TITLE
Add rbs:validate to rake ci

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 task default: :ci
 
-task ci: %i[rubocop spec steep]
+task ci: %i[rubocop spec steep rbs:validate]
 
 namespace :rbs do
   desc "Install RBS signatures"
@@ -20,6 +20,11 @@ namespace :rbs do
   desc "Generate RBS files"
   task :generate do
     sh "rbs-inline", "--opt-out", "--output=sig", "lib"
+  end
+
+  desc "Validate RBS files"
+  task validate: "rbs:install" do
+    sh "bundle exec rbs -Isig validate"
   end
 end
 


### PR DESCRIPTION
## Summary

Adds an `rbs:validate` task (`rbs -Isig validate`) to the ci chain so RBS signature well-formedness is checked alongside `steep`, completing alignment with the `init-ruby-project` skeleton. The rest of the Rakefile already followed the skeleton.

## Changes

- `Rakefile`
  - add `rbs:validate` (depends on `rbs:install`)
  - `task ci`: `rubocop spec steep` → `rubocop spec steep rbs:validate`

## Notes

- Rake dedupes prerequisites, so the collection is installed exactly once per `rake ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)