### PR TITLE
Align .rubocop.yml with shared skeleton baseline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,13 @@ Layout/LineLength:
 Metrics/AbcSize:
   Max: 20
 
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*_spec.rb"
+
+Metrics/ClassLength:
+  Max: 200
+
 Metrics/MethodLength:
   Max: 30
 
@@ -52,6 +59,12 @@ Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
 
 # Style
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
## Summary

Align this repository's `.rubocop.yml` with the shared `init-ruby-project`
skeleton so linting rules are consistent across all Ruby repositories.

## Config changes

- Add `Metrics/BlockLength`, `Metrics/ClassLength`, `Style/AccessorGrouping`,
  `Style/CommentedKeyword`
- Rules sorted in ASCII order to match the skeleton

`RSpec/MultipleMemoizedHelpers` and `RSpec/NestedGroups` stay disabled (more
permissive than the baseline). No code changes were required.

Verified locally with `rubocop` (bundle matching the lockfile) — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)