### PR TITLE
ci: Drop issues:write from RBS collection app token

### DIFF
--- a/.github/workflows/rbs_collection.yml
+++ b/.github/workflows/rbs_collection.yml
@@ -20,7 +20,6 @@ jobs:
         private-key: ${{ secrets.REPO_HOUSEKEEPER_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write
-        permission-issues: write
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false


### PR DESCRIPTION
## Problem

The `RBS collection` workflow fails at the `create-github-app-token` step with a 422 error:

```
The permissions requested are not granted to this installation.
```

## Cause

This workflow requested `permission-issues: write`, but the `REPO_HOUSEKEEPER` GitHub App is only granted **Contents** and **Pull requests** (read/write) — it does **not** have the Issues permission. Requesting a permission the App does not hold makes token creation fail.

This repository was the only one requesting `issues:write`. All other repositories and the `init-ruby-project` skeleton request only `contents` and `pull-requests`.

## Fix

Remove `permission-issues: write` to align this workflow with the skeleton and every other repository using the same App.

🤖 Generated with [Claude Code](https://claude.com/claude-code)