### PR TITLE
chore: catch up with the shared Ruby skeleton

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "permissions": {
-    "allow": ["RemoteTrigger"]
-  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - 'lib/ruby_lsp/rbs/inline/version.rb'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,10 +36,10 @@ Metrics/MethodLength:
 RSpec/ExampleLength:
   Enabled: false
 
-RSpec/MultipleMemoizedHelpers:
+RSpec/MultipleExpectations:
   Enabled: false
 
-RSpec/MultipleExpectations:
+RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
 RSpec/NamedSubject:
@@ -47,16 +47,6 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Enabled: false
-
-# RbsInline
-Style/RbsInline:
-  Mode: opt_out
-
-Style/RbsInline/MissingTypeAnnotation:
-  EnforcedStyle: doc_style_and_return_annotation
-
-Style/RbsInline/RedundantTypeAnnotation:
-  EnforcedStyle: doc_style_and_return_annotation
 
 # Style
 Style/AccessorGrouping:
@@ -70,6 +60,15 @@ Style/Documentation:
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: always
+
+Style/RbsInline:
+  Mode: opt_out
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Rakefile
+++ b/Rakefile
@@ -12,14 +12,23 @@ task default: :ci
 task ci: %i[rubocop spec steep rbs:validate]
 
 namespace :rbs do
-  desc "Install RBS signatures"
+  # sig/gems holds hand-written types for external gems, so it is never regenerated
+  kept = ->(path) { path == "sig/gems" || path.start_with?("sig/gems/") }
+
+  desc "Install RBS collection"
   task :install do
     sh "bundle exec rbs collection install --frozen"
   end
 
-  desc "Generate RBS files"
-  task :generate do
-    sh "rbs-inline", "--opt-out", "--output=sig", "lib"
+  desc "Regenerate all RBS files under sig/ from scratch (run manually after editing lib/)"
+  task :regenerate do
+    Dir.glob("sig/**/*.rbs").reject(&kept).each { rm _1 }
+
+    sh "bundle exec rbs-inline --opt-out --output=sig lib"
+
+    # Drop the directories the deletion above left empty, deepest first
+    dirs = Dir.glob("sig/**/*").select { File.directory?(_1) }
+    dirs.reject(&kept).sort.reverse_each { rmdir _1 if Dir.empty?(_1) }
   end
 
   desc "Validate RBS files"


### PR DESCRIPTION
## Summary

Same sweep as tk0miya/not_nilable#43, applied to this repository. Three commits, one topic each.

## `chore: replace rbs:generate with rbs:regenerate`

`rbs:generate` overwrote signatures in place, so a signature whose `lib/` source was deleted stayed behind in `sig/` forever. `rbs:regenerate` deletes the generated tree first and regenerates from scratch, keeping the hand-written `sig/gems/` stubs. The Rakefile is now identical to the skeleton's.

## `chore: drop the ineffective RemoteTrigger permission rule`

`RemoteTrigger` was never a real permission rule name. Upstream tried the actual MCP tool identifiers, verified those had no effect either, and removed the block entirely.

## `chore: fix rubocop.yml ordering and declare release.yml permissions`

`.rubocop.yml` claims ASCII ordering but `RSpec/MultipleMemoizedHelpers` preceded `RSpec/MultipleExpectations`, and the `Style/RbsInline` cops sat in their own section ahead of `Style/`. No cop configuration changes. `release.yml` was the one workflow without a top-level `permissions` block; its trigger path was checked against `lib/ruby_lsp/rbs/inline/version.rb` and is correct.

## Verification

Run locally against this branch:

- `bundle exec rake rbs:regenerate` — regenerates 4 signatures and leaves `sig/` **unchanged**, so the task is idempotent here.
- `bundle exec rake ci` — passes: rubocop, spec, steep ("No type error detected"), `rbs:validate`.
- `actionlint` — passes.
- `.claude/hooks/self-review.sh` is identical to the skill template, the Rakefile to the skeleton's, and every pinned action SHA was checked against the `tags` API.

No test cases were added: the changes are build, lint and hook configuration.

## Out of scope

This repository has never had `setup-ruby-hooks` applied — `.claude/hooks/` holds only `self-review.sh`, so there is no `protect-sig-files.sh` / `pre-commit-check.sh` / `rbs-inline.sh` to update here. Adopting them is a separate task, to be handled after this sweep lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)